### PR TITLE
Fixed a few memory leaks

### DIFF
--- a/src/tracebox/lua.cc
+++ b/src/tracebox/lua.cc
@@ -141,7 +141,7 @@ static int l_##obj##_Set##f(lua_State *l) \
 { \
 	obj *o= l_##obj##_check(l, 1); \
 	o->Set##f(luaL_check##t(l, 2)); \
-	return 1; \
+	return 0; \
 }
 
 #define l_getter(obj, f, t) \

--- a/src/tracebox/lua.cc
+++ b/src/tracebox/lua.cc
@@ -105,7 +105,7 @@ static int l_##obj##_destructor(lua_State *l) \
 { \
     obj *o= l_##obj##_check(l, 1); \
     delete o; \
-    return 1; \
+    return 0; \
 }
 
 #define l_hexdump(obj) \

--- a/src/tracebox/lua.cc
+++ b/src/tracebox/lua.cc
@@ -1058,6 +1058,8 @@ static int tCallback(void *ctx, int ttl, std::string& ip,
 	struct tracebox_info *info = (struct tracebox_info *)ctx;
 	int ret;
 
+    if (info->rcv)
+        delete info->rcv;
 	info->rcv = rcv;
 
 	if (!info->cb)
@@ -1118,7 +1120,7 @@ no_args:
 		return 0;
 	}
 
-	/* Did the server replied ? */
+	/* Did the server reply ? */
 	if (ret == 1 && info.rcv)
 		lua_pushPacket(l, (Packet *)info.rcv);
 	else
@@ -1247,7 +1249,7 @@ Packet *script_packet(std::string& cmd)
 	Packet *pkt = l_Packet_check(l, -1);
 	if (!pkt)
 		return NULL;
-	
+
 	return pkt;
 }
 

--- a/src/tracebox/tracebox.cc
+++ b/src/tracebox/tracebox.cc
@@ -494,6 +494,7 @@ static int Callback(void *ctx, int ttl, string& router,
 		if (mod)
 			mod->Print(cout, verbose);
 		cout << endl;
+        delete rcv;
 	} else
 		cout << ttl << ": *" << endl;
 


### PR DESCRIPTION
- delete rcv packet in the callbacks and not the main doTracebox() call
Rationale is that users (in cpp) could want to zero-copy the packets in a vector, so the callback is the owner of the pointer (hence the two delete in the 2 callbacks)

- clean up lua stack for setter/destructor
These fonction should return (void); so the stack should be completely empty after the calls (0).