### PR TITLE
Fix memory leak in callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: apt
 
 before_install:
 - sudo apt-get update -qq
-- sudo apt-get install -qq automake libtool lua5.2 liblua5.2-dev liblua5.2-0 libpcap-dev g++ autoconf gdb
+- sudo apt-get install -qq automake libtool lua5.2 liblua5.2-dev liblua5.2 liblua5.2-0-dbg libpcap-dev g++ autoconf gdb
 
 install:
 - sh bootstrap.sh --enable-tests

--- a/src/tracebox/PacketModification.cc
+++ b/src/tracebox/PacketModification.cc
@@ -107,7 +107,6 @@ static bool deleteAll(Modification *m)
 PacketModifications::~PacketModifications()
 {
 	delete orig;
-	delete modif;
 
 	for(const_iterator it = begin() ; it != end() ; it++)
 		delete *it;

--- a/src/tracebox/PacketModification.h
+++ b/src/tracebox/PacketModification.h
@@ -25,13 +25,13 @@
 using namespace Crafter;
 
 class Modification {
-	/* Representation of the modification */
-	std::string name;
-
 	/* Layer protocol where the modification occured. The protocol is as defined
 	 * in Libcrafter.
 	 */
 	int layer_proto;
+
+	/* Representation of the modification */
+	std::string name;
 
 	/* Offset compared to the start of the layer (in bits) */
 	size_t offset;
@@ -91,7 +91,7 @@ class PacketModifications : public std::vector<Modification *> {
 	Packet *modif;
 
 public:
-	PacketModifications(Packet *orig, Packet *modif) : orig(orig), modif(modif) { }
+	PacketModifications(Packet *orig, Packet *modif) : orig(new Packet(*orig)), modif(modif) { }
 	~PacketModifications();
 
 	void Print(std::ostream& out = std::cout, bool verbose = false) const;

--- a/src/tracebox/lua.cc
+++ b/src/tracebox/lua.cc
@@ -1058,8 +1058,6 @@ static int tCallback(void *ctx, int ttl, std::string& ip,
 	struct tracebox_info *info = (struct tracebox_info *)ctx;
 	int ret;
 
-	if (info->rcv)
-		delete info->rcv;
 	info->rcv = rcv;
 
 	if (!info->cb)

--- a/src/tracebox/tracebox.cc
+++ b/src/tracebox/tracebox.cc
@@ -491,8 +491,10 @@ static int Callback(void *ctx, int ttl, string& router,
 			cout << ttl << ": " << router << " ";
 		else
 			cout << ttl << ": " << GetHostname(router) << " (" << router << ") ";
-		if (mod)
+		if (mod) {
 			mod->Print(cout, verbose);
+			delete mod;
+		}
 		cout << endl;
 		delete rcv;
 	} else


### PR DESCRIPTION
- PacketModifications is owned by the callback
- removed the delete call in the lua callback, as we expose
the object on the lua stack, they are thus garbage collected.
- PacketModification should not delete the received packet
- PacketModification should copy the probe, as will be modified
in subsequent callback calls

Also added debug symbol for lualib to ease up debugging travis coredumps