### PR TITLE
Support set start TTL value by user.

### DIFF
--- a/src/tracebox/tracebox.1
+++ b/src/tracebox/tracebox.1
@@ -50,6 +50,8 @@ Use the specified port for static probe generated. Default is 80.
 Specify a network interface to operate with.
 .It \-m hops_max
 Set the max number of hops (max TTL to be reached). Default is 30.
+.It \-M hops_min
+Set the min number of hops (min TTL to be reached). Default is 1.
 .It \-p probe
 Specify the probe to send.
 .It \-l inline_script

--- a/src/tracebox/tracebox.cc
+++ b/src/tracebox/tracebox.cc
@@ -52,6 +52,8 @@ using namespace std;
 static bool skip_suid_check = false;
 
 static int hops_max = 64;
+static int hops_min = 0;
+
 static string destination;
 static string iface;
 static bool resolve = true;
@@ -503,7 +505,8 @@ int doTracebox(std::shared_ptr<Packet> pkt_shrd, tracebox_cb_t *callback,
 	if (!ip)
 		return -1;
 
-	for (int ttl = 1; ttl <= hops_max; ++ttl) {
+	hops_min = hops_min == 0 ? 1 : hops_min;
+	for (int ttl = hops_min; ttl <= hops_max; ++ttl) {
 		Packet* rcv = NULL;
 		PacketModifications *mod = NULL;
 		string sIP;
@@ -566,7 +569,7 @@ int main(int argc, char *argv[])
 
 	/* disable libcrafter warnings */
 	ShowWarnings = 0;
-	while ((c = getopt(argc, argv, "Sl:i:m:s:p:d:f:hnv6uwjt:"
+	while ((c = getopt(argc, argv, "Sl:i:M:m:s:p:d:f:hnv6uwjt:"
 #ifdef HAVE_CURL
 					"Cc:"
 #endif
@@ -577,6 +580,9 @@ int main(int argc, char *argv[])
 				break;
 			case 'i':
 				iface = optarg;
+				break;
+			case 'M':
+				hops_min = strtol(optarg, NULL, 10);
 				break;
 			case 'm':
 				hops_max = strtol(optarg, NULL, 10);
@@ -708,6 +714,8 @@ usage:
 "  -i device                   Specify a network interface to operate with\n"
 "  -m hops_max                 Set the max number of hops (max TTL to be reached).\n"
 "                              Default is 30.\n"
+"  -M hops_min                 Set the min number of hops (min TTL to be reached).\n"
+"                              Default is 1. \n"
 "  -v                          Print more information.\n"
 "  -j                          Change the format of the output to JSON.\n"
 "  -t timeout                  Timeout to wait for a reply after sending a packet.\n"

--- a/src/tracebox/tracebox.h
+++ b/src/tracebox/tracebox.h
@@ -25,6 +25,8 @@ IPLayer* probe_sanity_check(const Crafter::Packet *probe,
 int doTracebox(std::shared_ptr<Crafter::Packet> pkt, tracebox_cb_t *callback,
 		std::string& err, void *ctx = NULL);
 
+int set_tracebox_ttl_range(uint8_t ttl_min, uint8_t ttl_max);
+
 void writePcap(Packet* p);
 
 #ifdef HAVE_CURL


### PR DESCRIPTION
When test some IP/TCP options is supported by server or not, user can set
this option avoid start TTL from 1, which can test server only send one packet.